### PR TITLE
Musings on how to start multiple window support

### DIFF
--- a/src/Automation/Interfaces/IOutputFileHelper.cs
+++ b/src/Automation/Interfaces/IOutputFileHelper.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Axe.Windows.Automation
 {
     internal interface IOutputFileHelper
     {
         void EnsureOutputDirectoryExists();
-        string GetNewA11yTestFilePath();
+        string GetNewA11yTestFilePath(Func<string, string> decorator);
         void SetScanId(string scanId);
     } // interface
 } // namespace

--- a/src/Automation/OutputFileHelper.cs
+++ b/src/Automation/OutputFileHelper.cs
@@ -80,10 +80,11 @@ namespace Axe.Windows.Automation
                 _directory.CreateDirectory(_outputDirectory);
         }
 
-        public string GetNewA11yTestFilePath()
+        public string GetNewA11yTestFilePath(Func<string, string> decorator)
         {
+            Func<string, string> baseFileNameDecorator = decorator ?? ((name) => name);
             return Path.Combine(_outputDirectory,
-                GetBaseFileName() + ".a11ytest");
+                baseFileNameDecorator(GetBaseFileName()) + ".a11ytest");
         }
 
         private string GetBaseFileName()

--- a/src/Automation/SnapshotCommand.cs
+++ b/src/Automation/SnapshotCommand.cs
@@ -4,6 +4,7 @@
 using Axe.Windows.Automation.Resources;
 using Axe.Windows.Core.Bases;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
@@ -21,7 +22,7 @@ namespace Axe.Windows.Automation
         /// <param name="scanTools">A set of tools for writing output files,
         /// creating the expected results format, and finding the target element to scan</param>
         /// <returns>A SnapshotCommandResult that describes the result of the command</returns>
-        public static ScanResults Execute(Config config, IScanTools scanTools)
+        public static IReadOnlyCollection<ScanResults> Execute(Config config, IScanTools scanTools)
         {
             if (config == null) throw new ArgumentNullException(nameof(config));
             if (scanTools == null) throw new ArgumentNullException(nameof(scanTools));
@@ -35,28 +36,43 @@ namespace Axe.Windows.Automation
             if (config.CustomUIAConfigPath != null)
                 scanTools.Actions.RegisterCustomUIAPropertiesFromConfig(config.CustomUIAConfigPath);
 
-            var rootElements = scanTools.TargetElementLocator.LocateRootElements(config.ProcessId);
+            List<ScanResults> resultList = new List<ScanResults>();
 
-            return scanTools.Actions.Scan(rootElements?.First(), (element, elementId) =>
+            var rootElements = scanTools.TargetElementLocator.LocateRootElements(config.ProcessId).ToList();
+
+            int targetIndex = 1;
+
+            foreach (var rootElement in rootElements)
             {
-                return ProcessResults(element, elementId, config, scanTools);
-            });
+                resultList.Add(scanTools.Actions.Scan(rootElement, (element, elementId) =>
+                {
+                    return ProcessResults(element, elementId, config, scanTools, targetIndex++, rootElements.Count);
+                }));
+            }
+
+            return resultList;
         }
 
-        private static ScanResults ProcessResults(A11yElement element, Guid elementId, Config config, IScanTools scanTools)
+        private static ScanResults ProcessResults(A11yElement element, Guid elementId, Config config, IScanTools scanTools, int targetIndex, int targetCount)
         {
             if (scanTools == null) throw new ArgumentNullException(nameof(scanTools));
             if (scanTools.ResultsAssembler == null) throw new ArgumentException(ErrorMessages.ScanToolsResultsAssemblerNull, nameof(scanTools));
 
             var results = scanTools.ResultsAssembler.AssembleScanResultsFromElement(element);
 
-            if (results.ErrorCount > 0)
-                results.OutputFile = WriteOutputFiles(config.OutputFileFormat, scanTools, element, elementId);
+            if (targetCount > 0)
+            {
+                results.OutputFile = WriteOutputFiles(config.OutputFileFormat, scanTools, element, elementId, (name) => $"{name}_{targetIndex}_of_{targetCount}");
+            }
+            else if (results.ErrorCount > 0)
+            {
+                results.OutputFile = WriteOutputFiles(config.OutputFileFormat, scanTools, element, elementId, null);
+            }
 
             return results;
         }
 
-        private static OutputFile WriteOutputFiles(OutputFileFormat outputFileFormat, IScanTools scanTools, A11yElement element, Guid elementId)
+        private static OutputFile WriteOutputFiles(OutputFileFormat outputFileFormat, IScanTools scanTools, A11yElement element, Guid elementId, Func<string, string> decorator)
         {
             if (scanTools == null) throw new ArgumentNullException(nameof(scanTools));
             if (scanTools.OutputFileHelper == null) throw new ArgumentException(ErrorMessages.ScanToolsOutputFileHelperNull, nameof(scanTools));
@@ -69,7 +85,7 @@ namespace Axe.Windows.Automation
 
                 scanTools.OutputFileHelper.EnsureOutputDirectoryExists();
 
-                a11yTestOutputFile = scanTools.OutputFileHelper.GetNewA11yTestFilePath();
+                a11yTestOutputFile = scanTools.OutputFileHelper.GetNewA11yTestFilePath(decorator);
                 if (a11yTestOutputFile == null) throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ErrorMessages.VariableNull, nameof(a11yTestOutputFile)));
 
                 scanTools.Actions.SaveA11yTestFile(a11yTestOutputFile, element, elementId);


### PR DESCRIPTION
Some early thoughts on how to support multiple base windows. The code to expose the results to the user needs to be finished and the unit tests need to be revised, but this should start moving in a reasonable direction.

A decorator function is passed into `OutputFileHelper.GetNewA11yTestFilePath`. The decorator's job, if specified, is to modify the base filename to reflect its place in the multiple files. In this simple version, it just appends `_1_of_3` or something similar.